### PR TITLE
new args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-linkey
+Linkey
 =====
 
 Link checker for BBC News/WS Sites
@@ -8,10 +8,15 @@ The idea is to quickly check a page for broken links by doing a status check on 
 To use run 
 
 ```ruby
-./bin/linkey check URL /regex Filename
+./bin/linkey check URL BASEURL /regex Filename
 ```
 Example
 
 ```ruby
-./bin/linkey check http://www.live.bbc.co.uk/arabic /arabic arabic.md
+./bin/linkey check http://www.live.bbc.co.uk/arabic http://www.live.bbc.co.uk /arabic arabic.md
+```
+Another
+
+```ruby
+/bin/linkey check http://www.theguardian.com/technology/2014/feb/15/year-of-code-needs-reboot-teachers http://theguardian.com /technology news.md
 ```

--- a/lib/linkey/cli.rb
+++ b/lib/linkey/cli.rb
@@ -6,20 +6,20 @@ class Linkey::CLI < Thor
   include Thor::Actions
 
   desc "scan", "Save some URL's"
-  def scan(url, reg, filename)
-    html = Linkey::SaveLinks.new(url, reg, filename)
+  def scan(url, filename)
+    html = Linkey::SaveLinks.new(url, filename)
     html.check_page_links
   end
 
   desc "status", "checks links for errors"
-  def status(url, reg, filename)
-    status = Linkey::CheckResponse.new(url, reg, filename)
+  def status(url, base, reg, filename)
+    status = Linkey::CheckResponse.new(url, base, reg, filename)
     status.sort
   end
 
   desc "check", "A full linkey job"
-  def check(url, reg, filename)
-    scan(url, reg, filename)
-    status(url, reg, filename)
+  def check(url, base, reg, filename)
+    scan(url, filename)
+    status(url, base, reg, filename)
   end
 end

--- a/lib/linkey/html.rb
+++ b/lib/linkey/html.rb
@@ -1,11 +1,10 @@
 require 'linkey'
 
 class Linkey::SaveLinks
-  attr_accessor :url, :reg, :file_name
+  attr_accessor :url, :file_name
 
-  def initialize(url, reg, file_name)
+  def initialize(url, file_name)
     @url = url
-    @reg = reg
     @file_name = file_name
   end
 
@@ -14,6 +13,6 @@ class Linkey::SaveLinks
   end
 
   def check_page_links
-    puts `phantomjs "#{js_file}" "#{url}" "#{reg}" > "#{file_name}"`
+    puts `phantomjs "#{js_file}" "#{url}" > "#{file_name}"`
   end
 end

--- a/lib/linkey/ping.rb
+++ b/lib/linkey/ping.rb
@@ -11,10 +11,6 @@ class Linkey::CheckResponse
     @file_name = file_name
   end
 
-  def cut
-    url.gsub("#{reg}", '')
-  end
-
   def sort
     array = []
     links = File.read(file_name)

--- a/lib/linkey/ping.rb
+++ b/lib/linkey/ping.rb
@@ -2,10 +2,11 @@ require 'linkey'
 require 'open-uri'
 
 class Linkey::CheckResponse
-  attr_accessor :url, :reg, :file_name
+  attr_accessor :url, :base, :reg, :file_name
 
-  def initialize(url, reg, file_name)
+  def initialize(url, base, reg, file_name)
     @url = url
+    @base = base
     @reg = reg
     @file_name = file_name
   end
@@ -36,11 +37,11 @@ class Linkey::CheckResponse
     puts "Checking..."
     urls.each do |page_path|
       begin
-        gets = open(cut + page_path)
+        gets = open(base + page_path)
         status = gets.status.first
-        puts "Status is #{status} for #{cut}#{page_path}"
+        puts "Status is #{status} for #{base}#{page_path}"
       rescue OpenURI::HTTPError => ex
-        puts "Status is NOT GOOD for #{cut}#{page_path}" 
+        puts "Status is NOT GOOD for #{base}#{page_path}" 
       end  
     end
     puts "All Done!"


### PR DESCRIPTION
Changed from 3 to 4 args.  A base URL is now needed, this will join with the second part of the URL that is specified in the regex.  There is probably a better way to do this with regex, grabbing the beginning part, at least with this way, you can be exact with your URL.

![ad0b92n_460sa](https://f.cloud.github.com/assets/1492067/2181827/e68f34ec-9769-11e3-981e-2b7163dac97d.gif)
